### PR TITLE
Adapt dropout in SwinIR based on sample_config

### DIFF
--- a/AutoFormer/model/swinIR/network_swinir.py
+++ b/AutoFormer/model/swinIR/network_swinir.py
@@ -84,22 +84,27 @@ class Mlp(nn.Module):
         self.fc1 = LinearSuper(in_features, hidden_features)
         self.act = act_layer()
         self.fc2 = LinearSuper(hidden_features, out_features)
-        self.drop = nn.Dropout(drop)
+        # Note: We'll actually only end up using `sample_drop`. 
+        # `super_drop` is only for recording what was originally passed.
+        self.super_drop = drop
+        self.sample_drop = None
 
     def forward(self, x):
         x = self.fc1(x)
         x = self.act(x)
-        x = self.drop(x)
+        x = F.dropout(x, p=self.sample_drop, training=self.training)
         x = self.fc2(x)
-        x = self.drop(x)
+        x = F.dropout(x, p=self.sample_drop, training=self.training)
         return x
 
     def set_sample_config(self,
                           sample_embed_dim=None,
-                          sample_mlp_ratio=None
+                          sample_mlp_ratio=None,
+                          sample_drop=None,
                           ):
         self.fc1.set_sample_config(int(sample_embed_dim), int(sample_embed_dim * sample_mlp_ratio))
         self.fc2.set_sample_config(int(sample_embed_dim * sample_mlp_ratio), int(sample_embed_dim))
+        self.sample_drop = sample_drop
 
 
 def window_partition(x, window_size):
@@ -431,7 +436,7 @@ class SwinTransformerBlock(nn.Module):
         self.attn.set_sample_config(sample_embed_dim, sample_num_heads)
         self.norm1.set_sample_config(sample_embed_dim)
         self.norm2.set_sample_config(sample_embed_dim)
-        self.mlp.set_sample_config(sample_embed_dim, sample_mlp_ratio)
+        self.mlp.set_sample_config(sample_embed_dim, sample_mlp_ratio, sample_dropout)
 
 
 class PatchMerging(nn.Module):

--- a/AutoFormer/model/swinIR/network_swinir.py
+++ b/AutoFormer/model/swinIR/network_swinir.py
@@ -966,8 +966,6 @@ class SwinIR(nn.Module):
             self.absolute_pos_embed = nn.Parameter(torch.zeros(1, num_patches, embed_dim))
             trunc_normal_(self.absolute_pos_embed, std=.02)
 
-        self.pos_drop = nn.Dropout(p=drop_rate)
-
         # stochastic depth
         dpr = [x.item() for x in torch.linspace(0, drop_path_rate, sum(depths))]  # stochastic depth decay rule
 
@@ -1121,7 +1119,7 @@ class SwinIR(nn.Module):
         x = self.patch_embed(x)
         if self.ape:
             x = x + self.absolute_pos_embed
-        x = self.pos_drop(x)
+        x = F.dropout(x, p=self.sample_dropout, training=self.training)
 
         for layer in self.layers:
             x = layer(x, x_size)


### PR DESCRIPTION
## Context

The `AutoFormer` implementation decreases the dropout rate depending on sample_embed_dim. Say, original `droprate=0.6` for the supernet with `embed_dim=100`. Then for a `sample_embed_dim=80`, we get:
`sample_droprate = droprate * sample_embed_dim/embed_dim = 0.6 * 80/100 = 0.48`.

Assumption: This to have the dropout rate when applied be in proportion to the supernet param (i.e. `embed_dim`).

## In AutoFormer

- `Vision_TransformerSuper` adjusts `sample_dropout` to be `super_dropout` * `sample_embed_dim / super_embed_dim` where `sample_embed_dim` is that of the first `TransformerEncoderLayer` block.
- For each `TransformerEncoderLayer`, it is again based on the embed_dim of that block and the `super_embed_dim`
- `TransformerEncoderLayer` uses the `sample_attn_dropout` and `sample_dropout` but doesn't pass it on to `AttentionSuper` (which **has a static sample-independent dropout rate**).

## In SwinIR

- `SwinIR`: 
  - pos_drop uses `drop_rate` in forward, also passed to RSTB
  - attn_drop_rate: passed to RSTB
- `RSTB`
  - drop, attn_drop: passed to BasicLayer
- `BasicLayer`
  - drop, attn_drop: passed to `SwinTransformerBlock`
- `SwinTransformerBlock`
  - drop, attn_drop: passed to `WindowAttention`
  - drop: passed to `Mlp`
- `WindowAttention`
  - Uses both drop, attn_drop
- `Mlp`
  - Uses drop

So, do we update the dropouts in `WindowAttention` and `Mlp` or not?

Current thought, `TransformerEncoderLayer` in `AutoFormer` does use `sample_attn_dropout` and `sample_dropout`. The former is right after applying `AttentionSuper` which seems strange as there is already a dropout at the end of `AttentionSuper`. So it's like applying two dropouts in succession. The latter seems to map to the usage in `Mlp`. 

As such, following that practice, best guess seems to be to not use the sample dropout values in `WindowAttention` and only use it in `Mlp`. 